### PR TITLE
Set repositories to use HTTPS and enable GPG check

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -1,11 +1,11 @@
 ---
 - name: "(Debian/Ubuntu) Add NGINX Signing Key"
   apt_key:
-    url: http://nginx.org/keys/nginx_signing.key
+    url: https://nginx.org/keys/nginx_signing.key
 
 - name: "(Debian/Ubuntu) Add NGINX Repository"
   apt_repository:
     repo: "{{item}}"
   with_items:
-    - deb http://nginx.org/packages/mainline/{{ansible_distribution|lower}}/ {{ansible_distribution_release}} nginx
-    - deb-src http://nginx.org/packages/mainline/{{ansible_distribution|lower}}/ {{ansible_distribution_release}} nginx
+    - deb https://nginx.org/packages/mainline/{{ansible_distribution|lower}}/ {{ansible_distribution_release}} nginx
+    - deb-src https://nginx.org/packages/mainline/{{ansible_distribution|lower}}/ {{ansible_distribution_release}} nginx

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -3,16 +3,18 @@
   yum_repository:
     name: nginx
     description: Mainline CentOS NGINX Repository
-    baseurl: http://nginx.org/packages/mainline/centos/{{ansible_distribution_major_version|int}}/$basearch/
+    baseurl: https://nginx.org/packages/mainline/centos/{{ansible_distribution_major_version|int}}/$basearch/
     enabled: yes
-    gpgcheck: no
+    gpgkey: https://nginx.org/keys/nginx_signing.key
+    gpgcheck: yes
   when: ansible_distribution == "CentOS"
 
 - name: "(RedHat) Add NGINX Repository"
   yum_repository:
     name: nginx
     description: Mainline RedHat NGINX Repository
-    baseurl: http://nginx.org/packages/mainline/rhel/{{ansible_distribution_major_version|int}}/$basearch/
+    baseurl: https://nginx.org/packages/mainline/rhel/{{ansible_distribution_major_version|int}}/$basearch/
     enabled: yes
-    gpgcheck: no
+    gpgkey: https://nginx.org/keys/nginx_signing.key
+    gpgcheck: yes
   when: ansible_distribution == "RedHat"

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -1,6 +1,9 @@
 ---
+- name: "(SUSE/SLES) Add NGINX Signing Key"
+  rpm_key:
+    key: https://nginx.org/keys/nginx_signing.key
+
 - name: "(SUSE/SLES) Add NGINX Repository"
   zypper_repository:
     name: nginx
-    repo: http://nginx.org/packages/mainline/sles/12
-    disable_gpg_check: yes
+    repo: https://nginx.org/packages/mainline/sles/12


### PR DESCRIPTION
Because security is important, I set all repositories to use HTTPS and enabled GPG checks.